### PR TITLE
Dtype json polars 1.33

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - netcdf4 >=1.5.5,!=1.6.1
   - pandas >=2.1.0
   - pip
-  - polars>=1.24.0
+  - polars>=1.33.0
   - pooch
   - pre-commit
   - pydantic >=2.0

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -664,7 +664,7 @@ class CatalogFileDataReader:
                 .str.replace(',]$', ']')  # Remove trailing commas
                 .str.replace_all(
                     "'", '"'
-                )  # This is to do with the JSON spec- single versus double quotes
+                )  # This is to do with the JSON spec - single versus double quotes
                 .str.json_decode(dtype=pl.List(pl.Utf8))
                 for colname in converters.keys()
             ]

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -662,8 +662,10 @@ class CatalogFileDataReader:
                 .str.replace('^.', '[')  # Replace first/last chars with [ or ].
                 .str.replace('.$', ']')  # set/tuple => list
                 .str.replace(',]$', ']')  # Remove trailing commas
-                .str.replace_all("'", '"')
-                .str.json_decode()  # This is to do with the way polars reads json - single versus double quotes
+                .str.replace_all(
+                    "'", '"'
+                )  # This is to do with the JSON spec- single versus double quotes
+                .str.json_decode(dtype=pl.List(pl.Utf8))
                 for colname in converters.keys()
             ]
         )


### PR DESCRIPTION
## Change Summary

- Specifies that iterable columns are decoded to the polars dtype `pl.List[pl.Utf8]` when opening catalogs with polars. (see https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.Expr.str.json_decode.html)
- Update the ci/environment.yml to use `polars>=1.33.0`
## Related issue number

N/A

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
