### PR TITLE
Fix meta.yaml... again

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/intake_esm*.whl
+          python -c "import intake_esm; print(intake_esm.__version__)"
           echo "intake-esm-version=$(python -c "import intake_esm; print(intake_esm.__version__)")" >> $GITHUB_OUTPUT
 
   upload-to-pypi:


### PR DESCRIPTION
## Change Summary

- The step where we grabbed the version was only running on push - I'm pretty sure that's what broke it this time.