### PR TITLE
Search using polars

### DIFF
--- a/intake_esm/_search.py
+++ b/intake_esm/_search.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
+pl.Config.set_engine_affinity('streaming')
+
 
 def unpack_iterable_column(df: pd.DataFrame, column: str) -> pd.DataFrame:
     """Return a DataFrame where elements of a given iterable column have been unpacked into multiple lines."""

--- a/intake_esm/_search.py
+++ b/intake_esm/_search.py
@@ -161,9 +161,7 @@ def pl_search(
             )
         else:
             lf = lf.filter(
-                pl.col(colname)
-                .list.eval(pl.element().is_in(subquery, nulls_equal=True).any())
-                .explode()
+                pl.col(colname).list.eval(pl.element().is_in(subquery, nulls_equal=True)).list.any()
             )
 
     df = lf.collect().to_pandas()

--- a/intake_esm/_search.py
+++ b/intake_esm/_search.py
@@ -81,25 +81,20 @@ def pl_search(
     iterable_dtypes: dict[str, type] | None = None,
 ) -> pd.DataFrame:
     """
-    Search for entries in the catalog.
-
-    Parameters
-    ----------
-    df: :py:class:`~pandas.DataFrame`
-        A dataframe to search
+    lf: :py:class:`~polars.LazyFrame`
+        A lazy dataframe to search.
     query: dict
-        A dictionary of query parameters to execute against the dataframe
-    columns_with_iterables: list
-        Columns in the dataframe that have iterables
+        A dictionary of query parameters to execute against the lazy dataframe.
+    columns_with_iterables: set
+        Names of columns in the lazy dataframe whose values contain iterables.
     iterable_dtypes: dict, optional
         A dictionary mapping column names to their iterable dtypes. If not provided,
-        defaults to all tuple. Typically unused, unless a dataframe with eg. set
-        iterables has been passed explicitly.
-
+        tuple is assumed for iterable columns. Typically unused, unless a lazy
+        dataframe with, for example, set iterables has been passed explicitly.
     Returns
     -------
     dataframe: :py:class:`~pandas.DataFrame`
-        A new dataframe with the entries satisfying the query criteria.
+        A pandas dataframe containing the entries satisfying the query criteria.
 
     """
 

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -296,7 +296,7 @@ class ESMCatalogModel(pydantic.BaseModel):
             else:
                 cat._frames = FramesModel(
                     lf=pl.LazyFrame(cat.catalog_dict),
-                    df=pl.DataFrame(cat.catalog_dict).to_pandas(),
+                    # df=pl.DataFrame(cat.catalog_dict).to_pandas(),
                 )
 
             return cat

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -486,14 +486,17 @@ class ESMCatalogModel(pydantic.BaseModel):
             A new catalog with the entries satisfying the query criteria.
 
         """
-        if (_df := self._frames.df) is None:
+        if self._frames is None:
+            raise ValueError('FramesModel not instantiated. This should never happen.')
+
+        if self._frames.df is None:
             cols = list(self.lf.collect_schema().keys())
             col_subset = {
                 col for col, dtype in self.lf.collect_schema().items() if dtype == pl.Unknown
             }
             columns_with_iterables = {
                 col
-                for col, dtype in self._frames.lf.head(1)
+                for col, dtype in self._frames.lf.head(1)  # type: ignore[union-attr]
                 .select(col_subset)
                 .collect()
                 .schema.items()
@@ -546,7 +549,7 @@ class QueryModel(pydantic.BaseModel):
     model_config = ConfigDict(validate_assignment=False)
 
     @pydantic.model_validator(mode='after')
-    def validate_query(self) -> Self:
+    def validate_query(self) -> typing.Self:
         query = self.query
         columns = self.columns
         require_all_on = self.require_all_on
@@ -558,7 +561,7 @@ class QueryModel(pydantic.BaseModel):
         if isinstance(require_all_on, str):
             self.require_all_on = [require_all_on]
         if require_all_on is not None:
-            for key in self.require_all_on:
+            for key in self.require_all_on:  # type: ignore[union-attr]
                 if key not in columns:
                     raise ValueError(f'Column {key} not in columns {columns}')
         _query = query.copy()

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -487,7 +487,9 @@ class ESMCatalogModel(pydantic.BaseModel):
 
         """
         if self._frames is None:
-            raise ValueError('FramesModel not instantiated. This should never happen.')
+            raise ValueError(
+                'FramesModel not instantiated. This should never happen.'
+            )  # pragma: no cover
 
         if self._frames.df is None:
             cols = list(self.lf.collect_schema().keys())

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -10,14 +10,13 @@ import warnings
 from pathlib import Path
 
 import fsspec
-import packaging.version
 import pandas as pd
 import polars as pl
 import pydantic
 import tlz
 from pydantic import ConfigDict
 
-from ._search import search, search_apply_require_all_on
+from ._search import pl_search, search, search_apply_require_all_on
 from .iodrivers import (
     CatalogFileReader,
     CatalogFileWriter,
@@ -297,7 +296,6 @@ class ESMCatalogModel(pydantic.BaseModel):
             else:
                 cat._frames = FramesModel(
                     lf=pl.LazyFrame(cat.catalog_dict),
-                    pl_df=pl.DataFrame(cat.catalog_dict),
                     df=pl.DataFrame(cat.catalog_dict).to_pandas(),
                 )
 
@@ -467,6 +465,11 @@ class ESMCatalogModel(pydantic.BaseModel):
         """
         Search for entries in the catalog.
 
+        If the pandas dataframe has not yet been instantiated, we search the polars
+        dataframe, materialising the pandas dataframe only when necessary. If the
+        pandas dataframe has been instantiated, we search it instead, as searching
+        is cheap compared to materialisation.
+
         Parameters
         ----------
         query: dict, optional
@@ -483,24 +486,50 @@ class ESMCatalogModel(pydantic.BaseModel):
             A new catalog with the entries satisfying the query criteria.
 
         """
+        if (_df := self._frames.df) is None:
+            cols = list(self.lf.collect_schema().keys())
+            col_subset = {
+                col for col, dtype in self.lf.collect_schema().items() if dtype == pl.Unknown
+            }
+            columns_with_iterables = {
+                col
+                for col, dtype in self._frames.lf.head(1)
+                .select(col_subset)
+                .collect()
+                .schema.items()
+                if dtype == pl.List
+            }
+            use_pl = True
+        else:
+            use_pl = False
+            columns_with_iterables = self.columns_with_iterables
+            cols = self.df.columns.tolist()
 
         _query = (
             query
             if isinstance(query, QueryModel)
-            else QueryModel(
-                query=query, require_all_on=require_all_on, columns=self.df.columns.tolist()
-            )
+            else QueryModel(query=query, require_all_on=require_all_on, columns=cols)
         )
 
-        results = search(
-            df=self.df, query=_query.query, columns_with_iterables=self.columns_with_iterables
-        )
+        if use_pl:
+            results = pl_search(
+                lf=self.lf,
+                query=_query.query,
+                columns_with_iterables=columns_with_iterables,
+            )
+        else:
+            results = search(
+                df=self.df,
+                query=_query.query,
+                columns_with_iterables=columns_with_iterables,
+            )
+
         if _query.require_all_on is not None and not results.empty:
             results = search_apply_require_all_on(
                 df=results,
                 query=_query.query,
                 require_all_on=_query.require_all_on,
-                columns_with_iterables=self.columns_with_iterables,
+                columns_with_iterables=columns_with_iterables,
             )
         return results
 

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -486,6 +486,7 @@ class ESMCatalogModel(pydantic.BaseModel):
             A new catalog with the entries satisfying the query criteria.
 
         """
+
         if self._frames is None:
             raise ValueError(
                 'FramesModel not instantiated. This should never happen.'
@@ -493,13 +494,9 @@ class ESMCatalogModel(pydantic.BaseModel):
 
         if self._frames.df is None:
             cols = list(self.lf.collect_schema().keys())
-            col_subset = {
-                col for col, dtype in self.lf.collect_schema().items() if dtype == pl.Unknown
-            }
             columns_with_iterables = {
                 col
                 for col, dtype in self._frames.lf.head(1)  # type: ignore[union-attr]
-                .select(col_subset)
                 .collect()
                 .schema.items()
                 if dtype == pl.List

--- a/intake_esm/iodrivers.py
+++ b/intake_esm/iodrivers.py
@@ -76,13 +76,16 @@ class FramesModel(pydantic.BaseModel):
     def columns_with_iterables(self) -> set[str]:
         """Return a set of columns that have iterables, preferentially using
         `self.lazy` > `self.polars` > `self.pandas` to minimise overhead."""
+
+        trunc_df = None
         if self.lf is not None and (trunc_df := self.lazy.head(1).collect()).is_empty():
             return set()
 
         if self.df is not None and self.df.empty:
             return set()
 
-        trunc_df = self.lazy.head(1).collect()
+        if trunc_df is None:
+            trunc_df = self.lazy.head(1).collect()
 
         colnames, dtypes = trunc_df.columns, trunc_df.dtypes
         return {colname for colname, dtype in zip(colnames, dtypes) if dtype == pl.List}

--- a/intake_esm/iodrivers.py
+++ b/intake_esm/iodrivers.py
@@ -76,10 +76,13 @@ class FramesModel(pydantic.BaseModel):
     def columns_with_iterables(self) -> set[str]:
         """Return a set of columns that have iterables, preferentially using
         `self.lazy` > `self.polars` > `self.pandas` to minimise overhead."""
-        if (trunc_df := self.lazy.head(1).collect()).is_empty():
+        if self.lf is not None and (trunc_df := self.lazy.head(1).collect()).is_empty():
             return set()
+
         if self.df is not None and self.df.empty:
             return set()
+
+        trunc_df = self.lazy.head(1).collect()
 
         colnames, dtypes = trunc_df.columns, trunc_df.dtypes
         return {colname for colname, dtype in zip(colnames, dtypes) if dtype == pl.List}

--- a/intake_esm/iodrivers.py
+++ b/intake_esm/iodrivers.py
@@ -22,7 +22,6 @@ class FramesModel(pydantic.BaseModel):
     and lazyframe."""
 
     df: pd.DataFrame | None = None
-    pl_df: pl.DataFrame | None = None
     lf: pl.LazyFrame | None = None
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
@@ -30,11 +29,10 @@ class FramesModel(pydantic.BaseModel):
     @pydantic.model_validator(mode='after')
     def ensure_some(self) -> typing.Self:
         """
-        Make sure that at least one of the dataframes is not `None` when the model is
-        instantiated.
+        Make sure at least one of df, or lf is set.
         """
-        if self.df is None and self.pl_df is None and self.lf is None:
-            raise AssertionError('At least one of df, pl_df, or lf must be set')
+        if self.df is None and self.lf is None:
+            raise AssertionError('At least one of df, or lf must be set')
         return self
 
     @property
@@ -43,34 +41,24 @@ class FramesModel(pydantic.BaseModel):
         if self.df is not None:
             return self.df
 
-        if self.pl_df is not None:
-            self.df = self.pl_df.to_pandas(use_pyarrow_extension_array=False)
-            self.df[list(self.columns_with_iterables)] = self.df[
-                list(self.columns_with_iterables)
-            ].map(tuple)
-            return self.df
-
-        self.pl_df = self.lf.collect()  # type: ignore[union-attr]
-        self.df = self.pl_df.to_pandas(use_pyarrow_extension_array=False)
-        self.df[list(self.columns_with_iterables)] = self.df[list(self.columns_with_iterables)].map(
-            tuple
-        )
+        pl_df = self.lf.collect()  # type: ignore[union-attr]
+        self.df = pl_df.to_pandas(use_pyarrow_extension_array=True)
+        for colname in self.columns_with_iterables:
+            self.df[colname] = self.df[colname].apply(tuple)
         return self.df
 
     @property
     def polars(self) -> pl.DataFrame:
-        """Return the polars DataFrame, instantiating it if necessary."""
-        if self.pl_df is not None:
-            return self.pl_df
+        """Return the polars DataFrame, instantiating it preferentially from the
+        lazyframe but from the pandas dataframe if not."""
 
         if self.lf is not None:
-            self.pl_df = self.lf.collect()
-            return self.pl_df
+            return self.lf.collect()
 
-        self.pl_df = pl.from_pandas(self.df)
-        self.lf = self.pl_df.lazy()
+        pl_df = pl.from_pandas(self.df)
+        self.lf = pl_df.lazy()
 
-        return self.pl_df
+        return pl_df
 
     @property
     def lazy(self) -> pl.LazyFrame:
@@ -89,6 +77,8 @@ class FramesModel(pydantic.BaseModel):
         """Return a set of columns that have iterables, preferentially using
         `self.lazy` > `self.polars` > `self.pandas` to minimise overhead."""
         if (trunc_df := self.lazy.head(1).collect()).is_empty():
+            return set()
+        if self.df is not None and self.df.empty:
             return set()
 
         colnames, dtypes = trunc_df.columns, trunc_df.dtypes

--- a/intake_esm/iodrivers.py
+++ b/intake_esm/iodrivers.py
@@ -42,7 +42,7 @@ class FramesModel(pydantic.BaseModel):
             return self.df
 
         pl_df = self.lf.collect()  # type: ignore[union-attr]
-        self.df = pl_df.to_pandas(use_pyarrow_extension_array=True)
+        self.df = pl_df.to_pandas(use_pyarrow_extension_array=False)
         for colname in self.columns_with_iterables:
             self.df[colname] = self.df[colname].apply(tuple)
         return self.df

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -347,22 +347,16 @@ def test_query_model_mixed_iterables_preserved():
     assert q.query['var'] == ['tas', 'pr']
 
 
-# ------------------------------
-# FramesModel.ensure_some
-# ------------------------------
-
-
 def test_frames_model_ok_with_pandas_only():
     df = pd.DataFrame({'a': [1, 2]})
-    m = FramesModel(df=df, pl_df=None, lf=None)
+    m = FramesModel(df=df, lf=None)
     assert m.df is not None
-    assert m.pl_df is None
     assert m.lf is None
 
 
 def test_frames_model_error_when_all_none():
     with pytest.raises(ValidationError):
-        FramesModel(df=None, pl_df=None, lf=None)
+        FramesModel(df=None, lf=None)
 
 
 def test_esm_catalog_dates_are_pass_through():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -966,6 +966,7 @@ def test_df_reader_csv(catalog, df_reader, _driver):
         assert cat.esmcat._driver.frames.lf is not None
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize('df_reader', ['pandas', 'polars'])
 def test_search__frames_df_is_None(df_reader):
     """
@@ -982,6 +983,5 @@ def test_search__frames_df_is_None(df_reader):
         df_reader=df_reader,
     )
     result = cat.search(variable=['strairx_m', 'flatn_ai_m'], require_all_on=['file_id'])
-    breakpoint()
     assert isinstance(result.df, pd.DataFrame)
     assert len(result) == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -966,7 +966,6 @@ def test_df_reader_csv(catalog, df_reader, _driver):
         assert cat.esmcat._driver.frames.lf is not None
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('df_reader', ['pandas', 'polars'])
 def test_search__frames_df_is_None(df_reader):
     """
@@ -982,6 +981,7 @@ def test_search__frames_df_is_None(df_reader):
         columns_with_iterables=['variable'],
         df_reader=df_reader,
     )
+
     result = cat.search(variable=['strairx_m', 'flatn_ai_m'], require_all_on=['file_id'])
     assert isinstance(result.df, pd.DataFrame)
     assert len(result) == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -964,3 +964,24 @@ def test_df_reader_csv(catalog, df_reader, _driver):
         assert cat.esmcat._driver.frames.lf is None
         cat.esmcat._driver.frames.polars
         assert cat.esmcat._driver.frames.lf is not None
+
+
+@pytest.mark.parametrize('df_reader', ['pandas', 'polars'])
+def test_search__frames_df_is_None(df_reader):
+    """
+    Test that is EsmCatalogMoel._frames.df is None, we default to searching
+    with polars.
+
+    ---
+    Why wasn't this caught by our other tests? Why doesn't it work? WTF...
+    """
+
+    cat = intake.open_esm_datastore(
+        access_columns_with_lists_cat,
+        columns_with_iterables=['variable'],
+        df_reader=df_reader,
+    )
+    result = cat.search(variable=['strairx_m', 'flatn_ai_m'], require_all_on=['file_id'])
+    breakpoint()
+    assert isinstance(result.df, pd.DataFrame)
+    assert len(result) == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -493,11 +493,11 @@ def test_catalog_serialize(catalog_type, to_csv_kwargs, json_dump_kwargs, direct
     if directory is None:
         directory = os.getcwd()
     cat = intake.open_esm_datastore(f'{directory}/{name}.json')
-    subset_df = cat_subset.esmcat.pl_df.with_columns(
+    subset_df = cat_subset.esmcat.lf.collect().with_columns(
         [
             pl.col(colname).cast(pl.Null)
-            for colname in cat_subset.esmcat._frames.pl_df.columns
-            if cat_subset.esmcat._frames.pl_df.get_column(colname).is_null().all()
+            for colname in cat_subset.esmcat._frames.lf.collect().columns
+            if cat_subset.esmcat._frames.lf.collect().get_column(colname).is_null().all()
         ]
     )
 
@@ -507,11 +507,11 @@ def test_catalog_serialize(catalog_type, to_csv_kwargs, json_dump_kwargs, direct
     )
 
     # Cast all Nans to None for comparison here - unimportant in practice
-    df = cat.esmcat.pl_df.with_columns(
+    df = cat.esmcat.lf.collect().with_columns(
         [
             pl.col(colname).fill_nan(None)
-            for colname in cat.esmcat._frames.pl_df.columns
-            if cat.esmcat.pl_df.get_column(colname).dtype == pl.Float64
+            for colname in cat.esmcat._frames.lf.collect().columns
+            if cat.esmcat.lf.collect().get_column(colname).dtype == pl.Float64
         ]
     )
     df = df.with_columns(
@@ -961,6 +961,6 @@ def test_df_reader_csv(catalog, df_reader, _driver):
     assert isinstance(cat.esmcat._driver, _driver)
     if df_reader == 'pandas':
         cat.df
-        assert cat.esmcat._driver.frames.pl_df is None
+        assert cat.esmcat._driver.frames.lf is None
         cat.esmcat._driver.frames.polars
-        assert cat.esmcat._driver.frames.pl_df is not None
+        assert cat.esmcat._driver.frames.lf is not None

--- a/tests/test_iodrivers.py
+++ b/tests/test_iodrivers.py
@@ -21,6 +21,7 @@ from intake_esm.iodrivers import (
 )
 
 from .utils import (
+    access_columns_with_lists_cat,
     here,
     sample_df,
     sample_esmcat_data,
@@ -84,18 +85,23 @@ def test_FramesModel_no_accidental_pd(pd_df, lf, attr):
 
 def test_FramesModel_polars_from_lf():
     pd_df = None
-    pl_df = None
     lf = sample_lf
-    f = FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
+    f = FramesModel(df=pd_df, lf=lf)
 
     assert isinstance(f.polars, pl.DataFrame)
 
 
-def test_FramesModel_columns_with_iterables():
+@pytest.mark.parametrize(
+    'lf, pd_df',
+    [
+        (sample_lf.head(0), None),
+        (None, sample_df.head(0)),
+    ],
+)
+def test_FramesModel_columns_with_iterables(lf, pd_df):
     pd_df = None
-    pl_df = None
     lf = sample_lf.head(0)
-    f = FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
+    f = FramesModel(df=pd_df, lf=lf)
     assert f.columns_with_iterables == set()
 
 
@@ -111,6 +117,21 @@ def test_FramesModel_set_manual_df():
     expected_pl_df = pl.DataFrame({'numeric_col': [1, 2, 3], 'str_col': ['a', 'b', 'c']})
 
     pl_testing.assert_frame_equal(cat.pl_df, expected_pl_df)
+
+
+def test_FramesModel_applies_tuple():
+    """
+    Test that if we have a column with lists, we convert it to tuples in the pandas dataframe.
+    """
+    cat = ESMCatalogModel.load(
+        access_columns_with_lists_cat,
+        df_reader='polars',
+        read_kwargs={'converters': {'variable': ast.literal_eval}},
+    )
+
+    cat._frames.pandas
+
+    assert True
 
 
 def test_frames_model_ok_with_pandas_only():

--- a/tests/test_iodrivers.py
+++ b/tests/test_iodrivers.py
@@ -99,8 +99,11 @@ def test_FramesModel_polars_from_lf():
     ],
 )
 def test_FramesModel_columns_with_iterables(lf, pd_df):
-    pd_df = None
-    lf = sample_lf.head(0)
+    if lf is not None:
+        lf = sample_lf.head(0)
+    if pd_df is not None:
+        pd_df = sample_df.head(0)
+
     f = FramesModel(df=pd_df, lf=lf)
     assert f.columns_with_iterables == set()
 

--- a/tests/test_iodrivers.py
+++ b/tests/test_iodrivers.py
@@ -7,6 +7,7 @@ import polars as pl
 import pydantic
 import pytest
 from polars import testing as pl_testing
+from pydantic import ValidationError
 
 from intake_esm.cat import ESMCatalogModel
 from intake_esm.iodrivers import (
@@ -24,48 +25,45 @@ from .utils import (
     sample_df,
     sample_esmcat_data,
     sample_lf,
-    sample_pl_df,
 )
 
 
 @pytest.mark.parametrize(
-    'pd_df, pl_df, lf, err',
+    'pd_df, lf, err',
     [
-        (sample_df, sample_pl_df, sample_lf, False),
-        (sample_df, None, None, False),
-        (None, None, None, True),
-        (None, sample_pl_df, None, False),
-        (None, None, sample_lf, False),
+        (sample_df, sample_lf, False),
+        (sample_df, None, False),
+        (None, None, True),
+        (None, sample_lf, False),
     ],
 )
-def test_FramesModel_init(pd_df, pl_df, lf, err):
+def test_FramesModel_init(pd_df, lf, err):
     """
     Make sure FramesModel works with different input combos
     """
     if not err:
-        FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
+        FramesModel(df=pd_df, lf=lf)
         assert True
     else:
         with pytest.raises(pydantic.ValidationError):
-            FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
+            FramesModel(df=pd_df, lf=lf)
 
 
 @pytest.mark.parametrize(
-    'pd_df, pl_df, lf',
+    'pd_df, lf',
     [
-        (sample_df, sample_pl_df, sample_lf),
-        (sample_df, None, None),
-        (None, sample_pl_df, None),
-        (None, None, sample_lf),
+        (sample_df, sample_lf),
+        (sample_df, None),
+        (None, sample_lf),
     ],
 )
 @pytest.mark.parametrize('attr', ['polars', 'lazy', 'columns_with_iterables'])
-def test_FramesModel_no_accidental_pd(pd_df, pl_df, lf, attr):
+def test_FramesModel_no_accidental_pd(pd_df, lf, attr):
     """
     Make sure that if we instantiate with a polars dataframe or a lazy frame, we
     don't accidentally trigger the creation of a pandas dataframe.
     """
-    f = FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
+    f = FramesModel(df=pd_df, lf=lf)
 
     if pd_df is not None:
         assert f.df is not None
@@ -82,30 +80,6 @@ def test_FramesModel_no_accidental_pd(pd_df, pl_df, lf, attr):
         got_attr = getattr(f, attr)
         assert got_attr is not None
         assert f.df is not None
-
-
-def test_FramesModel_no_accidental_pl():
-    """
-    Make sure that if we instantiate with a pandas dataframe, we
-    don't accidentally trigger the creation of a polars dataframe.
-    """
-    pd_df = sample_df
-    pl_df = None
-    lf = None
-    f = FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
-
-    assert f.pl_df is None
-    assert f.polars is not None
-    assert f.pl_df is not None
-
-
-def test_FramesModel_pandas_from_pldf():
-    pd_df = None
-    pl_df = sample_pl_df
-    lf = None
-    f = FramesModel(df=pd_df, pl_df=pl_df, lf=lf)
-
-    assert isinstance(f.pandas, pd.DataFrame)
 
 
 def test_FramesModel_polars_from_lf():
@@ -127,25 +101,28 @@ def test_FramesModel_columns_with_iterables():
 
 def test_FramesModel_set_manual_df():
     """
-    Test that if we set esmcat._df, we don't cause an error. We also test that the
-    creation of `cat._frames.pl_df` is deferred until we ask for it with the
-    `cat.pl_df` property.
+    Test that if we set esmcat._df, we don't cause an error or our state to get wonky.
     """
     cat = ESMCatalogModel.from_dict({'esmcat': sample_esmcat_data, 'df': sample_df})
-
-    assert cat._frames.pl_df is None
 
     new_df = pd.DataFrame({'numeric_col': [1, 2, 3], 'str_col': ['a', 'b', 'c']})
     cat._df = new_df
 
-    assert getattr(cat, '_frames') is not None
-
-    pd.testing.assert_frame_equal(cat.df, new_df)
-
     expected_pl_df = pl.DataFrame({'numeric_col': [1, 2, 3], 'str_col': ['a', 'b', 'c']})
 
-    assert cat._frames.pl_df is None
     pl_testing.assert_frame_equal(cat.pl_df, expected_pl_df)
+
+
+def test_frames_model_ok_with_pandas_only():
+    df = pd.DataFrame({'a': [1, 2]})
+    m = FramesModel(df=df, lf=None)
+    assert m.df is not None
+    assert m.lf is None
+
+
+def test_frames_model_error_when_all_none():
+    with pytest.raises(ValidationError):
+        FramesModel(df=None, lf=None)
 
 
 @pytest.mark.parametrize('read_kwargs', [{}, {'converters': {'variable': ast.literal_eval}}])

--- a/tests/test_iodrivers.py
+++ b/tests/test_iodrivers.py
@@ -132,9 +132,9 @@ def test_FramesModel_applies_tuple():
         read_kwargs={'converters': {'variable': ast.literal_eval}},
     )
 
-    cat._frames.pandas
-
-    assert True
+    pandas_df = cat._frames.pandas
+    assert 'variable' in pandas_df.columns
+    assert pandas_df['variable'].map(lambda value: isinstance(value, tuple)).all()
 
 
 def test_frames_model_ok_with_pandas_only():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -217,6 +217,85 @@ def test_search_columns_with_iterables(query, expected):
     'query,expected',
     [
         (
+            dict(variable=['A', 'C']),
+            [
+                {
+                    'path': 'file1',
+                    'variable': ['A', 'B'],
+                    'attr': 1,
+                },
+                {
+                    'path': 'file2',
+                    'variable': ['A', 'B', 'C'],
+                    'attr': 2,
+                },
+                {
+                    'attr': 3,
+                    'path': 'file3',
+                    'variable': [
+                        'C',
+                        'D',
+                        'A',
+                    ],
+                },
+            ],
+        ),
+        (
+            dict(variable=['A', 'C'], attr=[1, 2]),
+            [
+                {
+                    'path': 'file1',
+                    'variable': ['A', 'B'],
+                    'attr': 1,
+                },
+                {
+                    'path': 'file2',
+                    'variable': ['A', 'B', 'C'],
+                    'attr': 2,
+                },
+            ],
+        ),
+    ],
+)
+def test_search_columns_with_iterables_str_specified(query, expected):
+    df = pd.DataFrame(
+        {
+            'path': ['file1', 'file2', 'file3'],
+            'variable': [['A', 'B'], ['A', 'B', 'C'], ['C', 'D', 'A']],
+            'attr': [1, 2, 3],
+        }
+    )
+
+    query_model = QueryModel(query=query, columns=df.columns.tolist())
+
+    lf = pl.from_pandas(df).lazy()
+
+    # This mirrors a setup step in the esmcat.search function which preserves dtypes.
+    # If altering this test, ensure that the dtypes are preserved here as well!
+    iterable_dtypes = {colname: type(df[colname].iloc[0]) for colname in {'variable'}}
+
+    results = search(
+        df=df,
+        query=query_model.query,
+        columns_with_iterables={
+            'variable',
+        },
+    )
+
+    results_pl = pl_search(
+        lf=lf,
+        query=query_model.query,
+        columns_with_iterables='variable',
+        iterable_dtypes=iterable_dtypes,
+    )
+    assert_frame_equal(results_pl, results)
+    assert results.to_dict(orient='records') == expected
+
+
+@pytest.mark.parametrize(
+    'query,expected',
+    [
+        (
             dict(variable=['A', 'B'], random='bx'),
             [
                 {'path': 'file1', 'variable': ['A', 'B'], 'attr': 1, 'random': {'bx', 'by'}},
@@ -276,3 +355,64 @@ def test_search_require_all_on_columns_with_iterables(query, expected):
     assert_frame_equal(results_pl, results)
 
     assert results.to_dict(orient='records') == expected
+
+
+def test_pattern_itercol_raises():
+    """
+    If we try to use pattern matching within iterable columns, we should raise a NotImplementedError.
+    """
+
+    df = pd.DataFrame(
+        {
+            'path': ['file1', 'file2', 'file3'],
+            'variable': [['A', 'B'], ['A', 'B', 'C'], ['C', 'D', 'A']],
+            'attr': [1, 2, 3],
+        }
+    )
+
+    query_model = QueryModel(query=dict(variable=[re.compile('^A$')]), columns=df.columns.tolist())
+
+    lf = pl.from_pandas(df).lazy()
+
+    with pytest.raises(
+        NotImplementedError,
+        match='Pattern matching within iterable columns is not implemented yet.',
+    ):
+        pl_search(
+            lf=lf,
+            query=query_model.query,
+            columns_with_iterables={'variable'},
+            iterable_dtypes={'variable': list},
+        )
+
+
+def test_numpy_dtypes_coerced_to_tuples():
+    """
+    If we have a column with numpy array values, we should coerce those to tuples
+    in the pandas dataframe. These numpy dtypes can arise from polars <=> pandas
+    conversions & from parquet serialised catalogues.
+    """
+
+    lf = pl.LazyFrame(
+        {
+            'path': ['file1', 'file2', 'file3'],
+            'variable': [
+                np.array(['A', 'B'], dtype=object),
+                np.array(['A', 'B', 'C'], dtype=object),
+                np.array(['C', 'D', 'A'], dtype=object),
+            ],
+            'attr': [1, 2, 3],
+        }
+    )
+
+    query_model = QueryModel(query=dict(variable=['A', 'C']), columns=['path', 'variable', 'attr'])
+
+    results_pl = pl_search(
+        lf=lf,
+        query=query_model.query,
+        columns_with_iterables={'variable'},
+        iterable_dtypes={'variable': np.ndarray},
+    )
+
+    assert isinstance(results_pl['variable'][0], tuple)
+    assert isinstance(results_pl['variable'][0][0], str)


### PR DESCRIPTION
Change search to operate using polars, following approach of https://github.com/intake/intake-esm/pull/767

The following description is copy/pasted from there:

___
# Change Summary

- Add a `_search.pl_search` function using polars (as lazily as I can), not pandas, if we don't have a pd.DataFrame instantiated. If we have one, we use the old `_search.search` function. 
- `esm_datastore.search()`still triggers the creation of a pandas dataframe, but well after 
- Remove the `pl_df` attribute from `FramesModel` - it just adds memory overhead & I don't think we're benefiting from keeping it around.
- Update all tests to ensure that the new search is the same as the old search.
- Explicitly add a `NotImplementedError` if users try to regex search over `columns_with_iterables` (it previously wasn't implemented but didn't raise an error, see #679). I've put some code beyond the error which I think should get that to work, but I think it would make more sense to split that out to a separate PR.


## Things I haven't changed

- `search_apply_require_all_on` still needs a pandas dataframe, so search still triggers the creation of a pandas dataframe. We can probably get away without doing this with some more work.


# Memory Profiling
```python
from memory_profiler import profile

from intake_esm.core import esm_datastore


@profile
def main():
    _ = 1
    cat = esm_datastore('/Users/u1166368/scratch/simulation.json')
    print("\nSearching for variable='tasmin'...\n")
    scat = cat.search(variable='tasmin')

    print('\n\nscat.df info:')
    print(scat.df.info())

    print('\n\ncat.df info:')
    print(cat.df.info())

    _srcs = scat.unique()


if __name__ == '__main__':
    main()

```
Gives (head of this branch)
```
python profile_intake_esm_pascal.py        2548ms  Thu Jan  8 16:12:04 2026

Searching for variable='tasmin'...

Filename: /Users/u1166368/catalog/intake-esm/intake_esm/_search.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    77    296.8 MiB    296.8 MiB           1   @profile
    78                                         def pl_search(
    79                                             *,
    80                                             lf: pl.LazyFrame,
    81                                             query: dict[str, typing.Any],
    82                                             columns_with_iterables: set,
    83                                             iterable_dtypes: dict[str, type] | None = None,
    84                                         ) -> pd.DataFrame:
    85                                             """
    86                                             Search for entries in the catalog.
    87                                         
    88                                             Parameters
    89                                             ----------
    90                                             df: :py:class:`~pandas.DataFrame`
    91                                                 A dataframe to search
    92                                             query: dict
    93                                                 A dictionary of query parameters to execute against the dataframe
    94                                             columns_with_iterables: list
    95                                                 Columns in the dataframe that have iterables
    96                                             iterable_dtypes: dict, optional
    97                                                 A dictionary mapping column names to their iterable dtypes. If not provided,
    98                                                 defaults to all tuple
    99                                         
   100                                             Returns
   101                                             -------
   102                                             dataframe: :py:class:`~pandas.DataFrame`
   103                                                 A new dataframe with the entries satisfying the query criteria.
   104                                         
   105                                             """
   106                                         
   107    296.8 MiB      0.0 MiB           1       if not query:
   108                                                 return lf.filter(pl.lit(False)).collect().to_pandas()
   109                                         
   110    336.0 MiB     39.2 MiB           1       full_schema = lf.head(1).collect().schema
   111                                         
   112    336.2 MiB      0.1 MiB           2       lf = lf.with_columns(
   113    336.2 MiB      0.1 MiB          24           [pl.col(colname).cast(full_schema[colname]) for colname in full_schema.keys()]
   114                                             )
   115                                         
   116    336.2 MiB      0.0 MiB           1       if isinstance(columns_with_iterables, str):
   117                                                 columns_with_iterables = [columns_with_iterables]
   118                                         
   119    336.2 MiB      0.0 MiB           1       iterable_dtypes = iterable_dtypes or {colname: tuple for colname in columns_with_iterables}
   120                                         
   121    336.2 MiB      0.0 MiB           1       for colname, dtype in iterable_dtypes.items():
   122                                                 if dtype == np.ndarray:
   123                                                     iterable_dtypes[colname] = tuple
   124                                         
   125    336.2 MiB      0.0 MiB           2       query_non_iterable = {
   126    336.2 MiB      0.0 MiB           3           key: val for key, val in query.items() if key not in columns_with_iterables
   127                                             }
   128                                         
   129    337.2 MiB      0.0 MiB           2       for colname, subquery in query_non_iterable.items():
   130    336.2 MiB      0.0 MiB           2           subquery = [None if pd.isna(subq) else subq for subq in subquery]
   131    336.2 MiB      0.0 MiB           1           if is_pattern(subquery):
   132                                                     case_insensitive = [
   133                                                         bool(q.flags & re.IGNORECASE) if isinstance(q, re.Pattern) else False
   134                                                         for q in subquery
   135                                                     ]
   136                                                     # Prepend (?i) to patterns for case insensitive matching if needed
   137                                                     subquery = [q.pattern if isinstance(q, re.Pattern) else q for q in subquery]
   138                                                     subquery = [f'(?i){q}' if ci else q for q, ci in zip(subquery, case_insensitive)]
   139                                         
   140                                                     lf = lf.filter(pl.col(colname).str.contains('|'.join(subquery), literal=False))
   141                                                 else:
   142    337.2 MiB      1.0 MiB           1               lf = lf.filter(pl.col(colname).is_in(subquery, nulls_equal=True))
   143                                         
   144    337.2 MiB      0.0 MiB           2       query_iterable = {key: val for key, val in query.items() if key in columns_with_iterables}
   145    337.2 MiB      0.0 MiB           1       for colname, subquery in query_iterable.items():
   146                                                 if is_pattern(subquery):
   147                                                     raise NotImplementedError(
   148                                                         'Pattern matching within iterable columns is not implemented yet.'
   149                                                     )
   150                                                     case_insensitive = [
   151                                                         bool(q.flags & re.IGNORECASE) if isinstance(q, re.Pattern) else False
   152                                                         for q in subquery
   153                                                     ]
   154                                                     # Prepend (?i) to patterns for case insensitive matching if needed
   155                                                     subquery = [q.pattern if isinstance(q, re.Pattern) else q for q in subquery]
   156                                                     subquery = [f'(?i){q}' if ci else q for q, ci in zip(subquery, case_insensitive)]
   157                                         
   158                                                     lf = lf.filter(
   159                                                         pl.col(colname)
   160                                                         .list.eval(pl.element().str.contains('|'.join(subquery), literal=False))
   161                                                         .any()
   162                                                     )
   163                                                 else:
   164                                                     lf = lf.filter(
   165                                                         pl.col(colname)
   166                                                         .list.eval(pl.element().is_in(subquery, nulls_equal=True).any())
   167                                                         .explode()
   168                                                     )
   169                                         
   170    475.0 MiB    137.8 MiB           1       df = lf.collect().to_pandas()
   171                                         
   172    475.0 MiB      0.0 MiB           1       for colname, dtype in iterable_dtypes.items():
   173                                                 df[colname] = df[colname].apply(dtype)
   174                                         
   175    475.0 MiB      0.0 MiB           1       return df


Filename: /Users/u1166368/catalog/intake-esm/intake_esm/cat.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   409    296.7 MiB    296.7 MiB           1       @profile
   410                                             def search(
   411                                                 self,
   412                                                 *,
   413                                                 query: QueryModel | dict[str, typing.Any],
   414                                                 require_all_on: str | list[str] | None = None,
   415                                             ) -> pd.DataFrame:
   416                                                 """
   417                                                 Search for entries in the catalog.
   418                                         
   419                                                 Parameters
   420                                                 ----------
   421                                                 query: dict, optional
   422                                                     A dictionary of query parameters to execute against the dataframe.
   423                                                 require_all_on : list, str, optional
   424                                                     A dataframe column or a list of dataframe columns across
   425                                                     which all entries must satisfy the query criteria.
   426                                                     If None, return entries that fulfill any of the criteria specified
   427                                                     in the query, by default None.
   428                                         
   429                                                 Returns
   430                                                 -------
   431                                                 catalog: ESMCatalogModel
   432                                                     A new catalog with the entries satisfying the query criteria.
   433                                         
   434                                                 """
   435                                         
   436                                                 # The way we get columns with iterables here looks a bit roundabout, but it
   437                                                 # minimizes memory overhead.
   438    296.8 MiB      0.1 MiB           1           cols = list(self.lf.collect_schema().keys())
   439    296.8 MiB      0.0 MiB          24           col_subset = {col for col, dtype in self.lf.collect_schema().items() if dtype == pl.Unknown}
   440                                         
   441    296.8 MiB      0.0 MiB           2           columns_with_iterables = {
   442                                                     col
   443    296.8 MiB      0.0 MiB           2               for col, dtype in self._frames.lf.head(1).select(col_subset).collect().schema.items()
   444                                                     if dtype == pl.List
   445                                                 }
   446                                         
   447    296.8 MiB      0.0 MiB           1           _query = (
   448                                                     query
   449    296.8 MiB      0.0 MiB           1               if isinstance(query, QueryModel)
   450    296.8 MiB      0.0 MiB           1               else QueryModel(query=query, require_all_on=require_all_on, columns=cols)
   451                                                 )
   452                                         
   453    296.8 MiB      0.0 MiB           1           if (_df := self._frames.df) is not None:
   454                                                     iterable_dtypes = {
   455                                                         colname: type(_df[colname].iloc[0]) for colname in columns_with_iterables
   456                                                     }
   457                                                 else:
   458    296.8 MiB      0.0 MiB           1               iterable_dtypes = None
   459                                         
   460    475.0 MiB    178.2 MiB           2           results = pl_search(
   461    296.8 MiB      0.0 MiB           1               lf=self.lf,
   462    296.8 MiB      0.0 MiB           1               query=_query.query,
   463    296.8 MiB      0.0 MiB           1               columns_with_iterables=columns_with_iterables,
   464    296.8 MiB      0.0 MiB           1               iterable_dtypes=iterable_dtypes,
   465                                                 )
   466                                         
   467    475.0 MiB      0.0 MiB           1           if _query.require_all_on is not None and not results.empty:
   468                                                     results = search_apply_require_all_on(
   469                                                         df=results,
   470                                                         query=_query.query,
   471                                                         require_all_on=_query.require_all_on,
   472                                                         columns_with_iterables=columns_with_iterables,
   473                                                     )
   474    475.0 MiB      0.0 MiB           1           return results




scat.df info:
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 25600 entries, 0 to 25599
Data columns (total 23 columns):
 #   Column                   Non-Null Count  Dtype 
---  ------                   --------------  ----- 
 0   id                       25600 non-null  object
 1   type                     25600 non-null  object
 2   processing_level         25600 non-null  object
 3   bias_adjust_institution  388 non-null    object
 4   bias_adjust_project      473 non-null    object
 5   bias_adjust_reference    0 non-null      object
 6   mip_era                  25600 non-null  object
 7   activity                 25600 non-null  object
 8   driving_model            12760 non-null  object
 9   driving_member           12760 non-null  object
 10  institution              25600 non-null  object
 11  source                   25600 non-null  object
 12  experiment               25600 non-null  object
 13  member                   13237 non-null  object
 14  xrfreq                   25600 non-null  object
 15  frequency                25600 non-null  object
 16  variable                 25600 non-null  object
 17  domain                   25600 non-null  object
 18  date_start               25600 non-null  object
 19  date_end                 25600 non-null  object
 20  version                  7240 non-null   object
 21  format                   25600 non-null  object
 22  path                     25600 non-null  object
dtypes: object(23)
memory usage: 4.5+ MB
None


cat.df info:
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 159277 entries, 0 to 159276
Data columns (total 23 columns):
 #   Column                   Non-Null Count   Dtype                
---  ------                   --------------   -----                
 0   id                       159277 non-null  large_string[pyarrow]
 1   type                     159277 non-null  large_string[pyarrow]
 2   processing_level         159277 non-null  large_string[pyarrow]
 3   bias_adjust_institution  1354 non-null    large_string[pyarrow]
 4   bias_adjust_project      1893 non-null    large_string[pyarrow]
 5   bias_adjust_reference    0 non-null       large_string[pyarrow]
 6   mip_era                  159277 non-null  large_string[pyarrow]
 7   activity                 159277 non-null  large_string[pyarrow]
 8   driving_model            109569 non-null  large_string[pyarrow]
 9   driving_member           109569 non-null  large_string[pyarrow]
 10  institution              159277 non-null  large_string[pyarrow]
 11  source                   159277 non-null  large_string[pyarrow]
 12  experiment               159277 non-null  large_string[pyarrow]
 13  member                   52497 non-null   large_string[pyarrow]
 14  xrfreq                   159277 non-null  large_string[pyarrow]
 15  frequency                159277 non-null  large_string[pyarrow]
 16  variable                 159277 non-null  large_string[pyarrow]
 17  domain                   159277 non-null  large_string[pyarrow]
 18  date_start               158367 non-null  large_string[pyarrow]
 19  date_end                 158367 non-null  large_string[pyarrow]
 20  version                  86294 non-null   large_string[pyarrow]
 21  format                   159277 non-null  large_string[pyarrow]
 22  path                     159277 non-null  large_string[pyarrow]
dtypes: large_string[pyarrow](23)
memory usage: 84.2 MB
None
Filename: /Users/u1166368/catalog/intake-esm/profile_intake_esm_pascal.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     6    230.7 MiB    230.7 MiB           1   @profile
     7                                         def main():
     8    230.7 MiB      0.0 MiB           1       _ = 1
     9    296.7 MiB     66.0 MiB           1       cat = esm_datastore('/Users/u1166368/scratch/simulation.json')
    10    296.7 MiB      0.0 MiB           1       print("\nSearching for variable='tasmin'...\n")
    11    481.2 MiB    184.5 MiB           1       scat = cat.search(variable='tasmin')
    12                                         
    13    481.2 MiB      0.0 MiB           1       print('\n\nscat.df info:')
    14    482.7 MiB      1.5 MiB           1       print(scat.df.info())
    15                                         
    16    482.7 MiB      0.0 MiB           1       print('\n\ncat.df info:')
    17    689.1 MiB    206.5 MiB           1       print(cat.df.info())
    18                                         
    19    727.6 MiB     38.5 MiB           1       _srcs = scat.unique()

```

With `intake-esm=2025.2.3`:
```python
Filename: /Users/u1166368/scratch/pascal_profile/profile_intake_esm_pascal.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     6    186.6 MiB    186.6 MiB           1   @profile
     7                                         def main():
     8    186.6 MiB      0.0 MiB           1       _ = 1
     9    397.8 MiB    211.2 MiB           1       cat = esm_datastore('/Users/u1166368/scratch/simulation.json')
    10    397.8 MiB      0.0 MiB           1       print("\nSearching for variable='tasmin'...\n")
    11    403.5 MiB      5.6 MiB           1       scat = cat.search(variable='tasmin')
    12                                         
    13    403.5 MiB      0.0 MiB           1       print('\n\nscat.df info:')
    14    404.2 MiB      0.8 MiB           1       print(scat.df.info())
    15                                         
    16    404.2 MiB      0.0 MiB           1       print('\n\ncat.df info:')
    17    404.3 MiB      0.1 MiB           1       print(cat.df.info())
    18                                         
    19    404.4 MiB      0.1 MiB           1       _srcs = scat.unique()
```

It looks like there might be some other memory management issues we'll need to clean up too, but presently I think that the initialisation & search memory usage should now be back in the same ballpark. 

___ 
# Search performance
```python
from intake_esm.core import esm_datastore
import timeit


def main():
    _ = 1
    cat = esm_datastore("/Users/u1166368/scratch/simulation.json")
    print("\nSearching for variable='tasmin'...\n")

    elapsed = timeit.timeit(lambda: cat.search(variable="tasmin"), number=10)

    print(f"Average time per search: {elapsed / 10:.4f} seconds")


if __name__ == "__main__":
    main()
```

- v2025.2.3 : `Average time per search: 0.0060 seconds`
- This branch: `Average time per search: 0.0340 seconds`

This is obviously quite a bit slower (~5x), which is not great. Rolling together opening & searching the datastore
```python
from intake_esm.core import esm_datastore
import timeit


def m():
    cat = esm_datastore("/Users/u1166368/scratch/simulation.json")
    cat.search(variable="tasmin")


def main():
    elapsed = timeit.timeit(lambda: m(), number=10)
    print(f"Average time per open and search: {elapsed / 10:.4f} seconds")


if __name__ == "__main__":
    main()
```
- This branch: `Average time per open and search: 0.0835 seconds`
- v2025.2.3: `Average time per open and search: 0.4668 seconds`


I suspect most of that search time increase is the instantiation of the pandas dataframe - I'm hoping to continue to defer this further, but this memory issue needs fixing first.


## Related issue number

#711 
#753 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable