### PR TITLE
Xarray error message changed - fix the catch

### DIFF
--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -306,10 +306,11 @@ class ESMDataSource(DataSource):
                         datasets, **self.xarray_combine_by_coords_kwargs
                     )
                 except ValueError as exc:
-                    if (
-                        str(exc)
-                        == 'Could not find any dimension coordinates to use to order the datasets for concatenation'
-                    ):
+                    if str(exc) in [
+                        # Error message changed in https://github.com/pydata/xarray/commit/ad92a166ee301302a02cc6f975d0899430806a86
+                        'Could not find any dimension coordinates to use to order the Dataset objects for concatenation',
+                        'Could not find any dimension coordinates to use to order the datasets for concatenation',
+                    ]:
                         warnings.warn(
                             'Attempting to concatenate datasets without valid dimension coordinates: retaining only first dataset.'
                             ' Request valid dimension coordinate to silence this warning.',


### PR DESCRIPTION
## Change Summary

- Add updated error string

## Related issue number

@rbeucher found this one in cosima-recipes/02-Appetisers-Barotropic_Streamfunction.ipynb

Turns out xarray just updated the error message, which I was matching the string on exactly. Added it to a list.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
