### PR TITLE
Static concat multifile

### DIFF
--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -306,10 +306,11 @@ class ESMDataSource(DataSource):
                         datasets, **self.xarray_combine_by_coords_kwargs
                     )
                 except ValueError as exc:
-                    if (
-                        str(exc)
-                        == 'Could not find any dimension coordinates to use to order the datasets for concatenation'
-                    ):
+                    if str(exc) in [
+                        # Error message changed in https://github.com/pydata/xarray/commit/ad92a166ee301302a02cc6f975d0899430806a86
+                        'Could not find any dimension coordinates to use to order the Dataset objects for concatenation',
+                        'Could not find any dimension coordinates to use to order the datasets for concatenation',
+                    ]:
                         warnings.warn(
                             'Attempting to concatenate datasets without valid dimension coordinates: retaining only first dataset.'
                             ' Request valid dimension coordinate to silence this warning.',

--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -316,7 +316,16 @@ class ESMDataSource(DataSource):
                             ' Request valid dimension coordinate to silence this warning.',
                             category=ConcatenationWarning,
                         )
-                        self._ds = datasets[0]
+                        # Minor wrinkle - if we have datasets with different variable names, then we *do* need to grab
+                        # more than just the first dataset.
+                        _n_unique_fnames = (
+                            self.df[self.variable_column_name].nunique()
+                            if self.variable_column_name
+                            else 1
+                        )
+                        # ^ TLDR; assume that if we have multiple datasets with different variable names, then we need those.
+                        # If we have multiple datasets with the same variable name, they're probably repeated grid files, etc.
+                        self._ds = datasets[:_n_unique_fnames]
                     else:
                         raise exc
 


### PR DESCRIPTION
TLDR; cases where we have something like 
```python
datastore.unique().variable
['dxu', 'time', 'xu_ocean', 'yu_ocean', 'dyu']
ipdb++> datastore.df
            filename                                               path  ...  realm temporal_label
0    ocean-2d-dxu.nc  /g/data/cj50/access-om2/raw-output/access-om2-...  ...  ocean          point
1    ocean-2d-dyu.nc  /g/data/cj50/access-om2/raw-output/access-om2-...  ...  ocean          point
2    ocean-2d-dxu.nc  /g/data/cj50/access-om2/raw-output/access-om2-...  ...  ocean          point
3    ocean-2d-dyu.nc  /g/data/cj50/access-om2/raw-output/access-om2-...  ...  ocean          point
4    ocean-2d-dxu.nc  /g/data/cj50/access-om2/raw-output/access-om2-...  ...  ocean          point
..               ...                                                ...  ...    ...            ...
```

Will cause us to drop df[1:]. This is a (sloppy) first pass at fixing that.